### PR TITLE
Align prev/next arrows relative to the borders

### DIFF
--- a/src/app/reviews/reviews.component.css
+++ b/src/app/reviews/reviews.component.css
@@ -13,7 +13,8 @@ a.arrow_prev {
   height:60px;
   overflow: hidden;
   position: absolute;
-  margin: 185px 0 0 -60px;
+  margin: 185px 0 0;
+  left: 0px;
 }
 
 a.arrow_next {
@@ -22,7 +23,8 @@ a.arrow_next {
   height:60px;
   overflow: hidden;
   position: absolute;
-  margin: 185px 0 0 720px;
+  margin: 185px 0 0;
+  right: 0px;
 }
 
 .row {


### PR DESCRIPTION
Align prev- and next-arrows in app-reviews context relative to their borders.